### PR TITLE
Add Specifying a string as the replacement eg $1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,31 @@ Download a release's `main.js`, `styles.css`, and `manifest.json` files and inst
 ## Usage
 
 Use the command palette and activate the `Global Search and Replace: Search and Replace in all files` command.
+
+### Specifying a string as the replacement
+
+The replacement string can include the following special replacement patterns:
+
+| Pattern   | Inserts                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| `$$`      | Inserts a `"$"`.                                                                               |
+| `$&`      | Inserts the matched substring.                                                                 |
+| `` $` ``  | Inserts the portion of the string that precedes the matched substring.                         |
+| `$'`      | Inserts the portion of the string that follows the matched substring.                          |
+| `$n`      | Inserts the `n`th (`1`-indexed) capturing group where `n` is a positive integer less than 100. |
+| `$<Name>` | Inserts the named capturing group where `Name` is the group name.                              |
+
+`$n` and `$<Name>` are only available if the `pattern` argument is a [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) object. If the `pattern` is a string, or if the corresponding capturing group isn't present in the regex, then the pattern will be replaced as a literal. If the group is present but isn't matched (because it's part of a disjunction), it will be replaced with an empty string.
+
+JSCopy to Clipboard
+
+```javascript
+"foo" replace /(f)/,"$2"
+// "$2oo"; the regex doesn't have the second group
+
+"foo" replace "f","$1"
+// "$1oo"; the pattern is a string, so it doesn't have any groups
+
+"foo" replace /(f)|(g)/,"$2"
+// "oo"; the second group exists but isn't matched
+```

--- a/src/domain/file-operator.ts
+++ b/src/domain/file-operator.ts
@@ -141,13 +141,18 @@ export class FileOperator {
 			}
 		);
 
-		editor.replaceSelection(replacementText);
+		const queryRegex = this.createQueryRegex(query, regexEnabled, caseSensitivityEnabled);
+
+		// Replace the selection with replacementText
+		if (regexEnabled) {
+			editor.replaceSelection(editor.getSelection().replaceAll(queryRegex, replacementText));
+		} else {
+			editor.replaceSelection(replacementText);
+		}
 
 		// Force flush of editor change to prevent race condition
 		// where if the user edits the query, stale results are returned for a ~1 second
 		await this.app.vault.modify(file, editor.getValue());
-
-		const queryRegex = this.createQueryRegex(query, regexEnabled, caseSensitivityEnabled);
 
 		// Necessary to update matchStartIndex and matchEndIndex for search results that were on the same line
 		const lineSearchResults = this.searchInLine(


### PR DESCRIPTION
I added some features
## example
![image](https://github.com/MahmoudFawzyKhalil/obsidian-global-search-and-replace/assets/64407174/8f94dc01-b65f-402c-991a-253b2e7a6e7f)
After replacement
![image](https://github.com/MahmoudFawzyKhalil/obsidian-global-search-and-replace/assets/64407174/5abac16b-1f33-480d-b01f-61512be9745c)

### [Specifying a string as the replacement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement)

The replacement string can include the following special replacement patterns:

|Pattern|Inserts|
|---|---|
|`$$`|Inserts a `"$"`.|
|`$&`|Inserts the matched substring.|
|`` $` ``|Inserts the portion of the string that precedes the matched substring.|
|`$'`|Inserts the portion of the string that follows the matched substring.|
|`$n`|Inserts the `n`th (`1`-indexed) capturing group where `n` is a positive integer less than 100.|
|`$<Name>`|Inserts the named capturing group where `Name` is the group name.|

`$n` and `$<Name>` are only available if the `pattern` argument is a [`RegExp`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) object. If the `pattern` is a string, or if the corresponding capturing group isn't present in the regex, then the pattern will be replaced as a literal. If the group is present but isn't matched (because it's part of a disjunction), it will be replaced with an empty string.

JSCopy to Clipboard

```javascript
"foo".replace(/(f)/, "$2");
// "$2oo"; the regex doesn't have the second group

"foo".replace("f", "$1");
// "$1oo"; the pattern is a string, so it doesn't have any groups

"foo".replace(/(f)|(g)/, "$2");
// "oo"; the second group exists but isn't matched
```
